### PR TITLE
Statistic tools

### DIFF
--- a/statistic_tools/program_publication_statistics.py
+++ b/statistic_tools/program_publication_statistics.py
@@ -1,0 +1,32 @@
+
+import ads
+
+
+if __name__=='__main__':
+   import os
+   import argparse
+
+   ads.config.token = os.environ.get('ADS_DEV_KEY')
+
+   parser = argparse.ArgumentParser(
+                    prog='program_publication_statistics',
+                    description='Given a NASA award or proposal number, this retrieves the publications that appear in ADS with taht proposal number in the acknowledgement.  This can also produce the number of publications by being provided a file of award or proposal numbers.  This needs to be run with either an award number of filename argument specified.')
+   parser.add_argument('-a', '--award', type=str, default=None, help='Award or proposal number')
+   parser.add_argument('-f', '--filename', default=None, help='File that is a list of awards or proposal numbers')
+   args = parser.parse_args()
+ 
+
+   if args.filename == None:
+      print(f"ack:{args.award}")
+      papers = ads.SearchQuery(q=f"ack:{args.award}", fl=["title", 'pub', 'property'])
+      for paper in papers:
+          print(paper.title, paper.pub, paper.property)
+   else:
+      with open(args.filename, 'r') as file:
+           awards = file.readlines()
+
+      for award in awards:
+          print(award)
+          papers = ads.SearchQuery(q=f"ack:{award}")
+          for paper in papers:
+              print(paper.title)

--- a/statistic_tools/scix_year_publications.py
+++ b/statistic_tools/scix_year_publications.py
@@ -1,0 +1,29 @@
+
+import ads
+
+
+if __name__=='__main__':
+   import os
+   import argparse
+
+   ads.config.token = os.environ.get('ADS_DEV_KEY')
+
+   parser = argparse.ArgumentParser(
+                    prog='scix_year_publications',
+                    description='Given a year, print a list of refrerreed publications from that year that have "supported by NASA" in the Acknowledgements')
+   parser.add_argument('year')
+   args = parser.parse_args()
+ 
+   return_format = ['title', 'pub', 'property', 'bibcode']
+   rows = 2000
+   start = 0
+   while True:
+      papers = ads.SearchQuery(q=f"year:{args.year} property:refereed full:'supported by NASA'", fl=return_format, rows=rows, start=start)
+
+      try:
+         for paper in papers:
+          openaccess = str("OPENACCESS" in paper.property)
+          print(paper.title[0] +'; ' + paper.pub + "; " +  openaccess + "; " + paper.bibcode) #paper.property)
+      except:
+         break
+      start = start + rows


### PR DESCRIPTION
Add two tools to identify publications from SciX.  These use the [ADS python library](https://ads.readthedocs.io/en/latest/) and this will need to be installed in order to use either of these tools. 